### PR TITLE
Don't close archive when FileObject streams close

### DIFF
--- a/src/main/java/com/github/junrar/vfs2/provider/rar/RARFileSystem.java
+++ b/src/main/java/com/github/junrar/vfs2/provider/rar/RARFileSystem.java
@@ -153,12 +153,4 @@ public class RARFileSystem extends AbstractFileSystem implements FileSystem {
         }
         return null;
     }
-
-    /**
-     * will be called after all file-objects closed their streams.
-     */
-    @Override
-    protected void notifyAllStreamsClosed() {
-        closeCommunicationLink();
-    }
 }

--- a/src/test/java/com/github/junrar/RarVfsTest.java
+++ b/src/test/java/com/github/junrar/RarVfsTest.java
@@ -42,8 +42,9 @@ public class RarVfsTest {
 
             assertThat(fileContent.getSize()).isEqualTo(7);
 
-            InputStream is = fileContent.getInputStream();
-            assertThat(IOUtils.toString(is, Charset.defaultCharset())).isEqualTo("file" + finalI + "\r\n");
+            try (InputStream is = fileContent.getInputStream()) {
+                assertThat(IOUtils.toString(is, Charset.defaultCharset())).isEqualTo("file" + finalI + "\r\n");
+            }
         }
     }
 


### PR DESCRIPTION
Currently, if you open an input stream for a file and then close it,
the entire archive is closed, but VFS will keep trying to use it, and
any future input streams you open will just close immediately (because
junrar silently swallows an NPE in the pipe writer thread).

The built-in providers have this same notifyAllStreamsClosed() method
commented out. It does not seem like correct behavior.